### PR TITLE
httpproxy: update import path for websocket pkg

### DIFF
--- a/httpproxy.go
+++ b/httpproxy.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"time"
 
-	"code.google.com/p/go.net/websocket"
+	"golang.org/x/net/websocket"
 )
 
 type HttpProxy struct {


### PR DESCRIPTION
The following change makes  the pkg go getable. 